### PR TITLE
Disable metrics collection

### DIFF
--- a/.github/workflows/collect_metrics.yaml
+++ b/.github/workflows/collect_metrics.yaml
@@ -7,6 +7,7 @@ on:
   
 jobs:  
   collect-and-upload-metrics:  
+    if: false
     runs-on: ubuntu-latest  
     permissions:  
       contents: read  # Read repo content (needed for repo object)  


### PR DESCRIPTION
Click the `Preview` tab and select a PR template:

- [Docs/Website-only change](?expand=1&template=docs_website_pr.md)
- [Other change](?expand=1&template=general_code_pr.md)

[//]: # (Dumb that we have to do this hack, see https://github.com/orgs/community/discussions/4620 for progress on github fixing this)